### PR TITLE
Add better README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,73 @@
-# Description
-This script compile your latex file as you are typing and create a differential pdf. It can be used to easily spot what you changed in your file because it uses red and blue to mark the modification.
-# How to use
-To use this script, simply execute this command in a terminal:
-```
-./Automatic_Latex_Differential.sh YOUR_TEX_FILE
-```
-Of course you may want to do the same but without de differential indications, for this use:
-```
-./Automatic_Latex_Compile.sh YOUR_TEX_FILE
-```
-To stop the script use `CTRL-C` or quit the terminal.
+# auto-latexdiff
 
-# How it works
-The script perpetually check the md5 of the give file, if it detects a change it will compile the file. It uses the command [latexdiff](https://github.com/ftilmann/latexdiff/) to generate the differential by comparing the edited file with a cached version.
-You can guess that it only see the change when the file is saved, if you want to see the changes appears as you type, enable the autosave feature of your text editor.
+`auto-latexdiff` compiles your LaTeX file as you are typing and creates a
+differential PDF. It can be used to easily spot what you changed in your file
+because it uses red and blue to mark the modification.
 
-# Thanks
-ftilmann for [latexdiff](https://github.com/ftilmann/latexdiff/) 
+---
+
+## Installation
+
+All you have to do is to clone the repository and go there:
+
+```
+git clone https://github.com/xorob0/auto-latexdiff
+cd auto-latexdiff
+```
+
+It's not difficult, is it?
+
+---
+
+## Usage
+
+```
+Usage: auto-latexdiff.sh [-hw] [-d OUTFILE] [DIR] [-f OUTFILE] [FILE]...
+Compiles your LaTeX file as you are typing and creates a differential PDF.
+
+    -d OUTFILE  specify the output directory (default to current)
+    -f OUTFILE  specify the output file
+    -h          display this help and exit
+    -r INTEGER  specify the refresh time
+    -w          compile without differential indications
+```
+
+The most classic case of use:
+
+```
+./auto-latexdiff -f latex_file
+```
+
+By default, `auto-latexdiff` will look for the LaTeX file in the current
+tree. However, you can change the default folder very simply:
+
+```
+./auto-latexdiff -d ~/Documents/LaTeX/ -f latex_file
+```
+
+Similarly, you can change the compilation refresh when you make different
+changes:
+
+```
+./auto-latexdiff -d ~/Documents/LaTeX/ -f latex_file -r 5
+```
+
+Finally, you can ignore the differential indicators with:
+
+```
+./auto-latexdiff -d ~/Documents/LaTeX/ -f latex_file -r 5 -w
+```
+
+---
+
+## Functioning
+
+The script constantly checks the `md5` of the given file. If it detects a
+change, it will compile the file again with `xelatex` and `latexdiff`.
+
+ `latexdiff` generates the differential by comparing the edited file
+ with a cached version.
+
+**NOTE:** you can guess that it only sees the change when the file is saved. If
+you want the changes to appear as you type, enable your text editor's automatic
+save function.


### PR DESCRIPTION
I thought about using the `auto-latexdiff` name for your repository which is shorter than `Automatic_Latex_Differential`. Therefore, I adapted the README according to this name and with the modifications made before.